### PR TITLE
Added Foreign & Composite Primary Key support to mysqloo driver

### DIFF
--- a/lua/sqlier/drivers/mysqloo.lua
+++ b/lua/sqlier/drivers/mysqloo.lua
@@ -113,8 +113,6 @@ function db:validateSchema(schema)
     end
 
     if istable(schema.Identity) and #schema.Identity > 0 then
-        print("Primary Keys Cache", schema.Identity)
-        PrintTable(schema.Identity)
         query = query .. "PRIMARY KEY (`" .. table.concat(schema.Identity, "`, `") .. "`), "
     end
 


### PR DESCRIPTION
### This change provides the following features:
 - Composite primary key
 - Foreign key relations
 
 Both without breaking changes.
 
### Example model:
 ```lua
-- Creates a table with composite primary key with one of them being foreign
 sqlier.Model({
  Table = "experience",
  Columns = {
    charid = {
      Type = sqlier.Type.Integer,
      Relation = {
        Table = "character",
        Column = "id"
      }
    },
    category = {
      Type = sqlier.Type.String,
      MaxLength = 120
    },
    amount = {
      Type = sqlier.Type.Integer,
      Default = 0
    }
  },
  Identity = { "charid", "category" }
})
 ```
 ### Limitation
 The limitation is the same as many other ORM's/Abstractions: 
 Tables must be created in the correct order otherwise sgdb will say reference table/column doesn't exist.
 This limitation should be easy to overcome and natural to any developer.