### PR TITLE
Add atomic transactions, conditional updateWhere & promise variants

### DIFF
--- a/lua/autorun/!sqlier_init.lua
+++ b/lua/autorun/!sqlier_init.lua
@@ -18,6 +18,59 @@ Database = {}
 Logger = include("sqlier/logger.lua")
 ModelBase = include("sqlier/model_base.lua")
 InstanceBase = include("sqlier/instance_base.lua")
+TransactionBuilder = include("sqlier/transaction.lua")
+
+-- Runs the operations queued inside `buildFn` atomically (all-or-nothing). The
+-- builder mirrors the model verbs, so no parallel "dialect" is needed:
+--
+--   sqlier.transaction(function(tx)
+--       tx:insert(Item, { ... })
+--       tx:decrement(Point, { ... })
+--   end, function(success, results)
+--       -- results[1].lastInsert
+--   end)
+--
+-- All operations must target the same database (one connection). Drivers without
+-- native transaction support degrade to sequential, non-atomic execution.
+function transaction(buildFn, callback)
+    local builder = TransactionBuilder.new()
+    buildFn(builder)
+
+    local operations = builder.operations
+
+    if #operations == 0 then
+        if isfunction(callback) then callback(true, {}) end
+        return
+    end
+
+    local database = Database[operations[1].model.Database]
+
+    if not database then
+        error("sqlier.transaction: could not resolve a database from the queued operations")
+    end
+
+    if isfunction(database.transaction) then
+        database:transaction(operations, callback)
+        return
+    end
+
+    -- Fallback: run sequentially (not atomic) on drivers that lack transactions.
+    for _, op in ipairs(operations) do
+        if op.kind == "insert" then
+            database:insert(op.model, op.object)
+        elseif op.kind == "update" then
+            database:update(op.model, op.object)
+        elseif op.kind == "delete" then
+            database:delete(op.model, op.identity)
+        elseif op.kind == "increment" then
+            database:increment(op.model, op.object)
+        elseif op.kind == "decrement" then
+            database:decrement(op.model, op.object)
+        end
+    end
+
+    if isfunction(callback) then callback(true, {}) end
+end
 
 function Initialize(database, driver, options)
     local db = include("sqlier/drivers/" .. driver .. ".lua")

--- a/lua/sqlier/drivers/mysqloo.lua
+++ b/lua/sqlier/drivers/mysqloo.lua
@@ -31,6 +31,115 @@ local function filterQuery(connection, table, filter)
     return query
 end
 
+-- Pure SQL builders, shared between the direct (Dataflow) methods and transactions.
+local function buildSet(connection, schema, object, separator)
+    local clause = ""
+
+    for key, value in pairs(object) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            clause = clause .. "`" .. key .. "` = '" .. escape(connection, value) .. "'" .. separator
+        end
+    end
+
+    return clause:sub(1, -(#separator + 1))
+end
+
+local function buildWhere(connection, schema, filter)
+    local clause = ""
+
+    for key, value in pairs(filter) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            clause = clause .. "`" .. key .. "` = '" .. escape(connection, value) .. "' AND "
+        end
+    end
+
+    return clause:sub(1, -6)
+end
+
+local function buildUpdate(connection, schema, object)
+    local where
+    local keyValues = ""
+
+    for key, value in pairs(object) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            if key == schema.Identity then
+                where = "`" .. key .. "` = '" .. escape(connection, value) .. "'"
+            else
+                keyValues = keyValues .. "`" .. key .. "`" .. " = '" .. escape(connection, value) .. "'" .. ", "
+            end
+        end
+    end
+
+    if #keyValues > 0 then
+        keyValues = keyValues:sub(1, -3)
+    end
+
+    return string.format("UPDATE `%s` SET %s WHERE %s", schema.Table, keyValues, where)
+end
+
+local function buildArithmetic(connection, schema, object, operator)
+    local where
+    local keyValues = ""
+
+    for key, value in pairs(object) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            if key == schema.Identity then
+                where = "`" .. key .. "` = '" .. escape(connection, value) .. "'"
+            elseif isnumber(value) then
+                keyValues = keyValues .. "`" .. key .. "`" .. " = `" .. key .. "` " .. operator .. " " .. value .. ", "
+            end
+        end
+    end
+
+    if #keyValues > 0 then
+        keyValues = keyValues:sub(1, -3)
+    end
+
+    return string.format("UPDATE `%s` SET %s WHERE %s", schema.Table, keyValues, where)
+end
+
+local function buildUpdateWhere(connection, schema, setValues, whereFilter)
+    return string.format("UPDATE `%s` SET %s WHERE %s",
+        schema.Table, buildSet(connection, schema, setValues, ", "), buildWhere(connection, schema, whereFilter))
+end
+
+local function buildDelete(connection, schema, identity)
+    return string.format("DELETE FROM `%s` WHERE `%s` = '%s'", schema.Table, schema.Identity, escape(connection, identity))
+end
+
+local function buildInsert(connection, schema, object)
+    local keys, values = "", ""
+
+    for key, value in pairs(object) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            keys = keys .. "`" .. key .. "`" .. ", "
+            values = values .. "'" .. escape(connection, value) .. "'" .. ", "
+        end
+    end
+
+    keys = keys:sub(1, -3)
+    values = values:sub(1, -3)
+
+    return string.format("INSERT INTO `%s`(%s) VALUES(%s)", schema.Table, keys, values)
+end
+
+-- Builds the SQL for one queued transaction operation (see sqlier.transaction).
+local function buildStatement(connection, op)
+    if op.kind == "insert" then
+        return buildInsert(connection, op.model, op.object)
+    elseif op.kind == "update" then
+        return buildUpdate(connection, op.model, op.object)
+    elseif op.kind == "delete" then
+        return buildDelete(connection, op.model, op.identity)
+    elseif op.kind == "increment" then
+        return buildArithmetic(connection, op.model, op.object, "+")
+    elseif op.kind == "decrement" then
+        return buildArithmetic(connection, op.model, op.object, "-")
+    end
+
+    error("Unknown transaction operation '" .. tostring(op.kind) .. "'")
+end
+
 function db:initialize(options)
     self.Connection = mysqloo.connect(options.address, options.user, options.password, options.database, options.port)
 
@@ -112,7 +221,9 @@ function db:query(query, callback)
 
     q.onSuccess = function(s, data)
         if callback then
-            callback(data)
+            -- Pass the query object as the second argument so callers can read
+            -- s:lastInsert() / s:affectedRows() (used by insert and updateWhere).
+            callback(data, s)
         end
     end
 
@@ -165,51 +276,25 @@ function db:find(schema, filter, callback)
 end
 
 function db:update(schema, object, callback)
-    local where
-    local keyValues = ""
-
-    for key, value in pairs(object) do
-        if schema.NormalizedColumnsCache[string.lower(key)] then
-            if key == schema.Identity then
-                where = "`" .. key .. "` = '" .. escape(self.Connection, value) .. "'"
-            else
-                keyValues = keyValues .. "`" .. key .. "`" .. " = '" .. escape(self.Connection, value) .. "'" .. ", "
-            end
-        end
-    end
-
-    if #keyValues > 0 then
-        keyValues = keyValues:sub(1, -3)
-    end
-
-    local query = "UPDATE `%s` SET %s WHERE %s"
-    self.Dataflow:enqueue(string.format(query, schema.Table, keyValues, where))
+    self.Dataflow:enqueue(buildUpdate(self.Connection, schema, object))
 
     if isfunction(callback) then
         callback()
     end
 end
 
-function db:increment(schema, object, callback)
-    local where
-    local keyValues = ""
-
-    for key, value in pairs(object) do
-        if schema.NormalizedColumnsCache[string.lower(key)] then
-            if key == schema.Identity then
-                where = "`" .. key .. "` = '" .. escape(self.Connection, value) .. "'"
-            elseif isnumber(value) then
-                keyValues = keyValues .. "`" .. key .. "`" .. " = `" .. key .. "` + " .. value .. ", "
-            end
+-- Conditional update returning the number of affected rows, e.g. an atomic claim
+-- like "set buyer where the listing is still unsold".
+function db:updateWhere(schema, setValues, whereFilter, callback)
+    self.Dataflow:enqueue(buildUpdateWhere(self.Connection, schema, setValues, whereFilter), function(_, q)
+        if isfunction(callback) then
+            callback(q and q:affectedRows() or 0)
         end
-    end
+    end)
+end
 
-    if #keyValues > 0 then
-        keyValues = keyValues:sub(1, -3)
-    end
-
-    local query = "UPDATE `%s` SET %s WHERE %s"
-    self.Dataflow:enqueue(string.format(query, schema.Table, keyValues, where))
+function db:increment(schema, object, callback)
+    self.Dataflow:enqueue(buildArithmetic(self.Connection, schema, object, "+"))
 
     if isfunction(callback) then
         callback()
@@ -217,59 +302,70 @@ function db:increment(schema, object, callback)
 end
 
 function db:decrement(schema, object, callback)
-    local where
-    local keyValues = ""
-
-    for key, value in pairs(object) do
-        if schema.NormalizedColumnsCache[string.lower(key)] then
-            if key == schema.Identity then
-                where = "`" .. key .. "` = '" .. escape(self.Connection, value) .. "'"
-            elseif isnumber(value) then
-                keyValues = keyValues .. "`" .. key .. "`" .. " = `" .. key .. "` - " .. value .. ", "
-            end
-        end
-    end
-
-    if #keyValues > 0 then
-        keyValues = keyValues:sub(1, -3)
-    end
-
-    local query = "UPDATE `%s` SET %s WHERE %s"
-    self.Dataflow:enqueue(string.format(query, schema.Table, keyValues, where))
+    self.Dataflow:enqueue(buildArithmetic(self.Connection, schema, object, "-"))
 
     if isfunction(callback) then
         callback()
     end
 end
 
-function db:delete(schema, identity)
-    local query = "DELETE FROM `%s` WHERE `%s` = '%s'"
-    self.Dataflow:enqueue(string.format(query, schema.Table, schema.Identity, escape(self.Connection, identity)))
+function db:delete(schema, identity, callback)
+    self.Dataflow:enqueue(buildDelete(self.Connection, schema, identity))
 
     if isfunction(callback) then
         callback(identity)
     end
 end
 
-function db:insert(schema, object)
-    local keys, values = "", ""
-
-    for key, value in pairs(object) do
-        if schema.NormalizedColumnsCache[string.lower(key)] then
-            keys = keys .. "`" .. key .. "`" .. ", "
-            values = values .. "'" .. escape(self.Connection, value) .. "'" .. ", "
+function db:insert(schema, object, callback)
+    self.Dataflow:enqueue(buildInsert(self.Connection, schema, object), function(_, q)
+        if isfunction(callback) then
+            callback(q and q:lastInsert())
         end
+    end)
+end
+
+-- Runs queued operations atomically (all-or-nothing) on a single connection.
+-- callback(success, results) where results[i] holds the per-statement
+-- data / affectedRows / lastInsert. On any error the whole batch rolls back.
+function db:transaction(operations, callback)
+    if self.Connection:status() ~= mysqloo.DATABASE_CONNECTED then
+        self:logError("Cannot start a transaction while disconnected.")
+        if isfunction(callback) then callback(false, "not connected") end
+        return
     end
 
-    keys = keys:sub(1, -3)
-    values = values:sub(1, -3)
+    local transaction = self.Connection:createTransaction()
+    local queries = {}
 
-    local query = "INSERT INTO `%s`(%s) VALUES(%s)"
-    local q = self.Dataflow:enqueue(string.format(query, schema.Table, keys, values))
-
-    if isfunction(callback) then
-        callback(q:lastInsert())
+    for index, op in ipairs(operations) do
+        local query = self.Connection:query(buildStatement(self.Connection, op))
+        queries[index] = query
+        transaction:addQuery(query)
     end
+
+    transaction.onSuccess = function()
+        if not isfunction(callback) then return end
+
+        local results = {}
+
+        for index, query in ipairs(queries) do
+            results[index] = {
+                data = query:getData(),
+                affectedRows = query:affectedRows(),
+                lastInsert = query:lastInsert()
+            }
+        end
+
+        callback(true, results)
+    end
+
+    transaction.onError = function(_, err)
+        self:logError("Transaction failed (rolled back): " .. tostring(err))
+        if isfunction(callback) then callback(false, err) end
+    end
+
+    transaction:start()
 end
 
 return db

--- a/lua/sqlier/drivers/sqlite.lua
+++ b/lua/sqlier/drivers/sqlite.lua
@@ -16,6 +16,115 @@ local function filterQuery(table, filter)
     return query
 end
 
+-- Pure SQL builders, shared between the direct methods and transactions.
+local function buildSet(schema, object, separator)
+    local clause = ""
+
+    for key, value in pairs(object) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            clause = clause .. "`" .. key .. "` = " .. sql.SQLStr(value) .. separator
+        end
+    end
+
+    return clause:sub(1, -(#separator + 1))
+end
+
+local function buildWhere(schema, filter)
+    local clause = ""
+
+    for key, value in pairs(filter) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            clause = clause .. "`" .. key .. "` = " .. sql.SQLStr(value) .. " AND "
+        end
+    end
+
+    return clause:sub(1, -6)
+end
+
+local function buildUpdate(schema, object)
+    local where
+    local keyValues = ""
+
+    for key, value in pairs(object) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            if key == schema.Identity then
+                where = "`" .. key .. "` = " .. sql.SQLStr(value)
+            else
+                keyValues = keyValues .. "`" .. key .. "`" .. " = " .. sql.SQLStr(value) .. ", "
+            end
+        end
+    end
+
+    if #keyValues > 0 then
+        keyValues = keyValues:sub(1, -3)
+    end
+
+    return string.format("UPDATE `%s` SET %s WHERE %s", schema.Table, keyValues, where)
+end
+
+local function buildArithmetic(schema, object, operator)
+    local where
+    local keyValues = ""
+
+    for key, value in pairs(object) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            if key == schema.Identity then
+                where = "`" .. key .. "` = " .. sql.SQLStr(value)
+            elseif isnumber(value) then
+                keyValues = keyValues .. "`" .. key .. "`" .. " = `" .. key .. "` " .. operator .. " " .. value .. ", "
+            end
+        end
+    end
+
+    if #keyValues > 0 then
+        keyValues = keyValues:sub(1, -3)
+    end
+
+    return string.format("UPDATE `%s` SET %s WHERE %s", schema.Table, keyValues, where)
+end
+
+local function buildUpdateWhere(schema, setValues, whereFilter)
+    return string.format("UPDATE `%s` SET %s WHERE %s",
+        schema.Table, buildSet(schema, setValues, ", "), buildWhere(schema, whereFilter))
+end
+
+local function buildDelete(schema, identity)
+    return string.format("DELETE FROM `%s` WHERE `%s` = %s", schema.Table, schema.Identity, sql.SQLStr(identity))
+end
+
+local function buildInsert(schema, object)
+    local keys, values = "", ""
+
+    for key, value in pairs(object) do
+        if schema.NormalizedColumnsCache[string.lower(key)] then
+            keys = keys .. "`" .. key .. "`" .. ", "
+            values = values .. sql.SQLStr(value) .. ", "
+        end
+    end
+
+    keys = keys:sub(1, -3)
+    values = values:sub(1, -3)
+
+    return string.format("INSERT INTO `%s`(%s) VALUES(%s)", schema.Table, keys, values)
+end
+
+-- Builds the SQL for one queued transaction operation (see sqlier.transaction).
+local function buildStatement(op)
+    if op.kind == "insert" then
+        return buildInsert(op.model, op.object)
+    elseif op.kind == "update" then
+        return buildUpdate(op.model, op.object)
+    elseif op.kind == "delete" then
+        return buildDelete(op.model, op.identity)
+    elseif op.kind == "increment" then
+        return buildArithmetic(op.model, op.object, "+")
+    elseif op.kind == "decrement" then
+        return buildArithmetic(op.model, op.object, "-")
+    end
+
+    error("Unknown transaction operation '" .. tostring(op.kind) .. "'")
+end
+
 function db:initialize()
 end
 
@@ -104,51 +213,24 @@ function db:find(schema, filter, callback)
 end
 
 function db:update(schema, object, callback)
-    local where
-    local keyValues = ""
-
-    for key, value in pairs(object) do
-        if schema.NormalizedColumnsCache[string.lower(key)] then
-            if key == schema.Identity then
-                where = "`" .. key .. "` = " .. sql.SQLStr(value)
-            else
-                keyValues = keyValues .. "`" .. key .. "`" .. " = " .. sql.SQLStr(value) .. ", "
-            end
-        end
-    end
-
-    if #keyValues > 0 then
-        keyValues = keyValues:sub(1, -3)
-    end
-
-    local query = "UPDATE `%s` SET %s WHERE %s"
-    self:query(string.format(query, schema.Table, keyValues, where))
+    self:query(buildUpdate(schema, object))
 
     if isfunction(callback) then
         callback()
     end
 end
 
+-- Conditional update returning the number of affected rows.
+function db:updateWhere(schema, setValues, whereFilter, callback)
+    self:query(buildUpdateWhere(schema, setValues, whereFilter))
+
+    if isfunction(callback) then
+        callback(tonumber(sql.QueryValue("SELECT changes()")) or 0)
+    end
+end
+
 function db:increment(schema, object, callback)
-    local where
-    local keyValues = ""
-
-    for key, value in pairs(object) do
-        if schema.NormalizedColumnsCache[string.lower(key)] then
-            if key == schema.Identity then
-                where = "`" .. key .. "` = " .. sql.SQLStr(value)
-            elseif isnumber(value) then
-                keyValues = keyValues .. "`" .. key .. "`" .. " = `" .. key .. "` - " .. value .. ", "
-            end
-        end
-    end
-
-    if #keyValues > 0 then
-        keyValues = keyValues:sub(1, -3)
-    end
-
-    local query = "UPDATE `%s` SET %s WHERE %s"
-    self:query(string.format(query, schema.Table, keyValues, where))
+    self:query(buildArithmetic(schema, object, "+"))
 
     if isfunction(callback) then
         callback()
@@ -156,25 +238,7 @@ function db:increment(schema, object, callback)
 end
 
 function db:decrement(schema, object, callback)
-    local where
-    local keyValues = ""
-
-    for key, value in pairs(object) do
-        if schema.NormalizedColumnsCache[string.lower(key)] then
-            if key == schema.Identity then
-                where = "`" .. key .. "` = " .. sql.SQLStr(value)
-            elseif isnumber(value) then
-                keyValues = keyValues .. "`" .. key .. "`" .. " = `" .. key .. "` - " .. value .. ", "
-            end
-        end
-    end
-
-    if #keyValues > 0 then
-        keyValues = keyValues:sub(1, -3)
-    end
-
-    local query = "UPDATE `%s` SET %s WHERE %s"
-    self:query(string.format(query, schema.Table, keyValues, where))
+    self:query(buildArithmetic(schema, object, "-"))
 
     if isfunction(callback) then
         callback()
@@ -182,8 +246,7 @@ function db:decrement(schema, object, callback)
 end
 
 function db:delete(schema, identity, callback)
-    local query = "DELETE FROM `%s` WHERE `%s` = %s"
-    self:query(string.format(query, schema.Table, schema.Identity, sql.SQLStr(identity)))
+    self:query(buildDelete(schema, identity))
 
     if isfunction(callback) then
         callback(identity)
@@ -191,23 +254,49 @@ function db:delete(schema, identity, callback)
 end
 
 function db:insert(schema, object, callback)
-    local keys, values = "", ""
-
-    for key, value in pairs(object) do
-        if schema.NormalizedColumnsCache[string.lower(key)] then
-            keys = keys .. "`" .. key .. "`" .. ", "
-            values = values .. sql.SQLStr(value) .. ", "
-        end
-    end
-
-    keys = keys:sub(1, -3)
-    values = values:sub(1, -3)
-
-    local query = "INSERT INTO `%s`(%s) VALUES(%s)"
-    self:query(string.format(query, schema.Table, keys, values))
+    self:query(buildInsert(schema, object))
 
     if isfunction(callback) then
         callback(sql.QueryValue("SELECT last_insert_rowid()"))
+    end
+end
+
+-- Runs queued operations atomically (all-or-nothing).
+-- callback(success, results) where results[i] holds the per-statement
+-- data / affectedRows / lastInsert. On any error the whole batch rolls back.
+function db:transaction(operations, callback)
+    sql.Query("BEGIN")
+
+    local results = {}
+    local failure
+
+    for index, op in ipairs(operations) do
+        local result = sql.Query(buildStatement(op))
+
+        if result == false then
+            failure = sql.LastError()
+            break
+        end
+
+        local entry = { data = result }
+
+        -- Only fetch the metadata each operation can actually produce.
+        if op.kind == "insert" then
+            entry.lastInsert = tonumber(sql.QueryValue("SELECT last_insert_rowid()"))
+        else
+            entry.affectedRows = tonumber(sql.QueryValue("SELECT changes()"))
+        end
+
+        results[index] = entry
+    end
+
+    if failure then
+        sql.Query("ROLLBACK")
+        self:logError("Transaction failed (rolled back): " .. tostring(failure))
+        if isfunction(callback) then callback(false, failure) end
+    else
+        sql.Query("COMMIT")
+        if isfunction(callback) then callback(true, results) end
     end
 end
 

--- a/lua/sqlier/extensions/promises.lua
+++ b/lua/sqlier/extensions/promises.lua
@@ -31,3 +31,23 @@ function sqlier.InstanceBase:deleteAsync()
         self:delete(resolve)
     end)
 end
+
+function sqlier.ModelBase:updateWhereAsync(setValues, whereFilter)
+    return util.Promise(function(resolve, reject)
+        self:updateWhere(setValues, whereFilter, resolve)
+    end)
+end
+
+-- Resolves with the per-statement results on commit, rejects with the error on
+-- rollback.
+function sqlier.transactionAsync(buildFn)
+    return util.Promise(function(resolve, reject)
+        sqlier.transaction(buildFn, function(success, results)
+            if success then
+                resolve(results)
+            else
+                reject(results)
+            end
+        end)
+    end)
+end

--- a/lua/sqlier/model_base.lua
+++ b/lua/sqlier/model_base.lua
@@ -82,6 +82,14 @@ function model_base:database()
     return sqlier.Database[self.Database]
 end
 
+-- Conditional update: sets `setValues` on every row matching `whereFilter` and
+-- reports how many rows were affected. Useful for atomic claims, e.g.
+--   Listing:updateWhere({ BuyerSid64 = buyer }, { Id = id, BuyerSid64 = "" }, fn)
+-- where the callback receives 1 only for the caller that won the race.
+function model_base:updateWhere(setValues, whereFilter, callback)
+    self:database():updateWhere(self, setValues, whereFilter, callback)
+end
+
 function model_base:__validate()
     self:database():validateSchema(self)
 end

--- a/lua/sqlier/transaction.lua
+++ b/lua/sqlier/transaction.lua
@@ -1,0 +1,36 @@
+-- Builder handed to sqlier.transaction(fn, callback). It collects operations by
+-- mirroring the model verbs (insert/update/delete/increment/decrement); the
+-- collected list is then run atomically by the driver.
+local transaction = {}
+transaction.__index = transaction
+
+function transaction.new()
+    return setmetatable({ operations = {} }, transaction)
+end
+
+function transaction:insert(model, object)
+    self.operations[#self.operations + 1] = { kind = "insert", model = model, object = object }
+    return self
+end
+
+function transaction:update(model, object)
+    self.operations[#self.operations + 1] = { kind = "update", model = model, object = object }
+    return self
+end
+
+function transaction:increment(model, object)
+    self.operations[#self.operations + 1] = { kind = "increment", model = model, object = object }
+    return self
+end
+
+function transaction:decrement(model, object)
+    self.operations[#self.operations + 1] = { kind = "decrement", model = model, object = object }
+    return self
+end
+
+function transaction:delete(model, identity)
+    self.operations[#self.operations + 1] = { kind = "delete", model = model, identity = identity }
+    return self
+end
+
+return transaction


### PR DESCRIPTION
## `sqlier.transaction(fn, callback)`

Runs several writes **all-or-nothing**. The builder mirrors the model verbs, so there's no parallel string dialect to learn:

```lua
sqlier.transaction(function(tx)
    tx:insert(Item,  { SteamId64 = sid, ItemId = "hat", Equipped = 0 })
    tx:decrement(Point, { SteamId64 = sid, Points = 500 })
end, function(success, results)
    -- results[1].lastInsert  (per-statement: data / affectedRows / lastInsert)
end)
```

`tx` exposes `insert / update / delete / increment / decrement`. All operations must target the same database (one connection). On any error the whole batch rolls back. Implemented natively on **mysqloo** (`Connection:createTransaction()`) and **sqlite** (`BEGIN`/`COMMIT`/`ROLLBACK`); drivers without it fall back to sequential, non-atomic execution.

## `Model:updateWhere(set, where, callback)`

A conditional `UPDATE` that reports the affected row count — enough for an atomic claim without a transaction:

```lua
Listing:updateWhere(
    { BuyerSid64 = buyer },
    { Id = id, BuyerSid64 = "" },     -- only an unclaimed row matches
    function(affected) --[[ ==1 means this caller won ]] end)
```

## Promises

Matching the existing `*Async` convention (so `:Await()` / `:next()` work as elsewhere):

- `sqlier.transactionAsync(fn)` — resolves with results on commit, rejects on rollback.
- `Model:updateWhereAsync(set, where)` — resolves with the affected count.

## Drive-by fixes pulled in by the refactor

- **mysqloo `insert()` now reports the new row id.** It previously had no `callback` parameter, so `instance:save()` on an auto-increment model never received `createdId`. `db:query()` now passes the query object as a second callback arg so callers can read `lastInsert()` / `affectedRows()`.
- **sqlite `increment()` fixed** — it subtracted instead of adding.
- SQL building extracted into shared `build*` helpers in each driver, used by the direct methods, `updateWhere`, and transactions.

## Scope / testing

`updateWhere` and `transaction` are implemented on the mysqloo and sqlite drivers (the persistent ones); the memory/file/cache drivers aren't covered here.

⚠️ Authored without a live MySQL/mysqloo or GMod instance. Syntax verified; the transaction paths (`createTransaction()` semantics, per-query `affectedRows()`/`lastInsert()`) and `updateWhere` affected-row counts should be smoke-tested on a real server before relying on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)